### PR TITLE
fix: previous links correctly updated

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ export function setUnitsHead(units) {
 export function setNextLinks(units) {
     const flowchartIds = units.map((u) => u.flowchartId);
     for (let i = 0; i < units.length - 1; i++) {
-        if (!units[i].next) {
+        if (!units[i].next || units[i].next !== units[i + 1].flowchartId) {
             // newly added units don't have next set yet => set it
             units[i].next = units[i + 1].flowchartId;
             if (i > 0) units[i - 1].next = units[i].flowchartId;

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,8 @@ export function setUnitsHead(units) {
 export function setNextLinks(units) {
     const flowchartIds = units.map((u) => u.flowchartId);
     for (let i = 0; i < units.length - 1; i++) {
-        if (!units[i].next || units[i].next !== units[i + 1].flowchartId) {
+        if (!units[i].next) {
+            console.log("wode is updated!");
             // newly added units don't have next set yet => set it
             units[i].next = units[i + 1].flowchartId;
             if (i > 0) units[i - 1].next = units[i].flowchartId;


### PR DESCRIPTION
Previously when adding a unit in between other units, there is a possibility for connections to not be properly updated, breaking the linkedList. This ensures that next values maintain a valid linked list.