### PR TITLE
fix: don't let a single unrenderable input abort the whole workflow render

### DIFF
--- a/dist/js/units/ExecutionUnitInput.js
+++ b/dist/js/units/ExecutionUnitInput.js
@@ -33,14 +33,24 @@ class ExecutionUnitInput extends entity_1.InMemoryEntity {
         try {
             const rendered = nunjucks_1.default.compile(this.template.content, env).render(renderingContext);
             this.rendered = rendered || this.template.content;
-            return this;
         }
         catch (error) {
+            // Can happen transiently right after switching to a multi-material workflow (e.g.
+            // interface left/right units keyed by MATERIAL_INDEX "1"/"2"), before the job's
+            // materials have been updated to match: `input.perMaterial[MATERIAL_INDEX]` is
+            // undefined until enough materials are assigned. This throwing used to propagate out
+            // of `ExecutionUnit.render()` and up through the JOB_WORKFLOW_SYNC/JOB_UPDATE
+            // reducers, aborting the whole dispatch - so the workflow selection itself silently
+            // never applied to the job (job-designer's `onSelectWorkflowsSubmit` just logs the
+            // rejected promise). Fall back to the raw template so the reducer can complete;
+            // render() runs again on the next job/material update and renders correctly once
+            // materials line up.
             console.error("Error rendering template", this.template.content);
             console.error("Rendering context: ", JSON.stringify(renderingContext));
             console.error("Error", error);
-            throw error;
+            this.rendered = this.template.content;
         }
+        return this;
     }
 }
 (0, ExecutionUnitInputSchemaMixin_1.executionUnitInputSchemaMixin)(ExecutionUnitInput.prototype);

--- a/src/js/units/ExecutionUnitInput.ts
+++ b/src/js/units/ExecutionUnitInput.ts
@@ -55,14 +55,24 @@ class ExecutionUnitInput extends InMemoryEntity implements Schema {
             const rendered = nunjucks.compile(this.template.content, env).render(renderingContext);
 
             this.rendered = rendered || this.template.content;
-
-            return this;
         } catch (error) {
+            // Can happen transiently right after switching to a multi-material workflow (e.g.
+            // interface left/right units keyed by MATERIAL_INDEX "1"/"2"), before the job's
+            // materials have been updated to match: `input.perMaterial[MATERIAL_INDEX]` is
+            // undefined until enough materials are assigned. This throwing used to propagate out
+            // of `ExecutionUnit.render()` and up through the JOB_WORKFLOW_SYNC/JOB_UPDATE
+            // reducers, aborting the whole dispatch - so the workflow selection itself silently
+            // never applied to the job (job-designer's `onSelectWorkflowsSubmit` just logs the
+            // rejected promise). Fall back to the raw template so the reducer can complete;
+            // render() runs again on the next job/material update and renders correctly once
+            // materials line up.
             console.error("Error rendering template", this.template.content);
             console.error("Rendering context: ", JSON.stringify(renderingContext));
             console.error("Error", error);
-            throw error;
+            this.rendered = this.template.content;
         }
+
+        return this;
     }
 }
 


### PR DESCRIPTION
## Summary
- `ExecutionUnitInput.render()` rethrew on any Nunjucks template error. That propagates uncaught through `ExecutionUnit.render()` -> `Subworkflow.render()` -> `Workflow.render()` -> `job.render()`, which job-designer's `JOB_WORKFLOW_SYNC`/`JOB_UPDATE` reducers call unconditionally.
- Selecting a multi-material workflow (e.g. Valence Band Offset, whose interface-left/right units are keyed by `MATERIAL_INDEX` `"1"`/`"2"` into `input.perMaterial`) while the job still only has its single default material makes `perMaterial[1]`/`[2]` undefined, which the `sprintf` filter throws on - crashing the reducer and silently aborting the workflow selection itself. job-designer's `onSelectWorkflowsSubmit` only `console.error`s the rejected promise, so the UI just stays on the old workflow with no visible error to the user.
- Fix: fall back to the raw (unrendered) template on error instead of rethrowing, matching the function's existing `this.rendered = rendered || this.template.content` fallback for empty output. The debug `console.error` logging is preserved. The next job/material update re-runs `render()` and produces a correct preview once enough materials are assigned.

## Root cause chain (for reviewers)
1. `reference/job-designer/src/reducers/renderJobForDesignerState.js` calls `job.render()` unconditionally on every `JOB_UPDATE`/`JOB_WORKFLOW_SYNC`.
2. `Workflow.render()` -> `Subworkflow.render()` -> `ExecutionUnit.render()` render **every** unit in **every** subworkflow, not just the one currently visible.
3. VBO's standata definition (`reference/standata/data/workflows/workflows/espresso/valence_band_offset.json`) has "Set Material Index" assignment units setting `MATERIAL_INDEX` to `"0"`/`"1"`/`"2"` for its combined/left/right branches, and several unit templates guard on `subworkflowContext.MATERIAL_INDEX` to index into `input.perMaterial[...]`.
4. Right after selecting this workflow (before the user assigns the 3 required materials), the job still has 1 material, so `perMaterial` has only index `0` - `perMaterial[1]`/`perMaterial[2]` are `undefined`.
5. `ExecutionUnitInput.render()` calls the custom `sprintf` filter (`reference/standata/src/js/utils/template.ts`) with `undefined`, which throws `TypeError: [sprintf] expecting number but found undefined` - previously uncaught here, now handled.

## Test plan
- [x] `npm test` in `reference/wode` - 47/47 passing, no regressions.
- [x] Live repro in a real browser session against a local web-app + Meteor server: before the fix, selecting "Valence Band Offset (2D)" on a job with the default single material silently kept the old "Total Energy" workflow active (confirmed via DOM inspection + matching console errors). After the fix (verified via a locally patched `node_modules` copy + full rspack cache clear/restart), the workflow correctly switches, all 7 VBO subworkflows populate, and the "average ESP" unit (the element `job-espresso-valence-band-offset.feature` needs) is present and clickable.
- [x] Re-ran `cypress run --spec cypress/e2e/jobs/run/job-espresso-valence-band-offset.feature` in web-app: previously failed at "I open 'average ESP' subworkflow unit" (never found); now progresses past that entirely into a later, unrelated bug (duplicate "cutoffs" panel in Important Settings causing an ambiguous `cy.focus()` match - tracked separately, not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)